### PR TITLE
docs: clarify http or https required in url; count in deployment resource in template

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Apply the Helm chart to start streaming logs into your Coder instance:
 helm repo add coder-logstream-kube https://helm.coder.com/logstream-kube
 helm install coder-logstream-kube coder-logstream-kube/coder-logstream-kube \
     --namespace coder \
-    --set url=<your-coder-url>
+    --set url=<your-coder-url-including-http-or-https>
 ```
 
 > **Note**
@@ -32,6 +32,7 @@ Your Coder template should be using a `kubernetes_deployment` resource with `wai
 
 ```hcl
 resource "kubernetes_deployment" "hello_world" {
+  count = data.coder_workspace.me.start_count  
   wait_for_rollout = false
   ...
 }

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-# url -- The URL of your Coder deployment.
+# url -- The URL of your Coder deployment. Must prefix with http or https
 url: ""
 
 # namespace -- The namespace to searching for Pods within.


### PR DESCRIPTION
This PR addresses a couple gotchas when using logstream:

1. `http` or `https` is required in the helm values
2. A `count` is required in the template `deployment` or the pod will create on a workspace stop