### PR TITLE
feat(helm): add volume mounts & cert vars

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -61,3 +61,17 @@ spec:
               value: {{ .Values.url }}
             - name: CODER_NAMESPACE
               value: {{  .Values.namespace | default .Release.Namespace }}
+            {{- if .Values.image.sslCertFile }}
+            - name: SSL_CERT_FILE
+              value: {{ .Values.image.sslCertFile }}
+            {{- end }}
+            {{- if .Values.image.sslCertDir }}
+            - name: SSL_CERT_DIR
+              value: {{ .Values.image.sslCertDir }}
+            {{- end }}
+          {{- if .Values.volumeMounts }}
+          volumeMounts: {{- toYaml .Values.volumeMounts | nindent 12 }}
+          {{- end }}
+      {{- if .Values.volumes }}
+      volumes: {{- toYaml .Values.volumes | nindent 8 }}
+      {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -5,6 +5,16 @@ url: ""
 # If unspecified, this defaults to the Helm namespace.
 namespace: ""
 
+# volumes -- A list of extra volumes to add to the coder-logstream pod.
+volumes:
+  #   emptyDir: {}
+  # - name: "my-volume"
+
+# volumeMounts -- A list of extra volume mounts to add to the coder-logstream pod.
+volumeMounts:
+  # - name: "my-volume"
+  #   mountPath: "/mnt/my-volume"
+
 # image -- The image to use.
 image:
   # image.repo -- The repository of the image.
@@ -21,6 +31,12 @@ image:
   # a private registry.
   pullSecrets: []
   #  - name: "pull-secret"
+  # image.sslCertFile -- Location of the SSL certificate file. Sets the $SSL_CERT_FILE
+  # variable inside of the container.
+  sslCertFile: ""
+  # image.sslCertDir -- Directory to check for SSL certificate files. Sets the $SSL_CERT_DIR
+  # variable inside of the container.
+  sslCertDir: ""
 
 serviceAccount:
   # serviceAccount.annotations -- The service account annotations.


### PR DESCRIPTION
closes #9 

this PR adds support for mounting volumes into the `coder-logstream-kube` container, and adds values for configuring the `SSL_CERT_FILE` and `SSL_CERT_DIR` envrionment variables.

since our customers typically leverage self-signed certificates, they need to add the Coder server certificate into `coder-logstream-kube` to establish the connection. here's an example `values.yaml` file that accomplishes this use-case:


```yaml
volumes:
  - name: "my-volume"
    secret:
      secretName: cert-secret
volumeMounts:
  - name: "my-volume"
    mountPath: "/mnt/my-volume"
image:
  sslCertFile: "/mnt/my-volume/cert.crt"
  sslCertDir: "/mnt/my-volume"
```
