### PR TITLE
feat(helm): add nodeSelector var

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -50,6 +50,10 @@ spec:
       imagePullSecrets:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: coder-logstream-kube
           image: "{{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/values.yaml
+++ b/values.yaml
@@ -45,3 +45,6 @@ serviceAccount:
   labels: {}
   # coder.serviceAccount.name -- The service account name
   name: coder-logstream-kube
+
+# nodeSelector -- Node labels for constraining the coder-logstream pod to specific nodes.
+nodeSelector: {}


### PR DESCRIPTION
This PR adds support for specifying the `nodeSelector` labels, allowing users to control on which nodes the `coder-logstream-kube` pod is scheduled.