### PR TITLE
feat: add support for pod labels

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -43,6 +43,9 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name | quote }}
       restartPolicy: Always

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -43,7 +43,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/instance: {{ .Release.Name }}
-        {{- with .Values.podLabels }}
+        {{- with .Values.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -48,3 +48,8 @@ serviceAccount:
 
 # nodeSelector -- Node labels for constraining the coder-logstream pod to specific nodes.
 nodeSelector: {}
+
+# labels -- The pod labels for coder-logstream-kube. See:
+# https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels:
+  eric: is awesome

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -51,5 +51,4 @@ nodeSelector: {}
 
 # labels -- The pod labels for coder-logstream-kube. See:
 # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-podLabels:
-  eric: is awesome
+labels: {}


### PR DESCRIPTION
adds support for the `podLabels` value, to set labels on the Deploymet pod. requested by a large customer.