### PR TITLE
fix: fix build.sh script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,5 +40,5 @@ else
     VERSION=$(../scripts/version.sh)
     BASE=ghcr.io/coder/coder-logstream-kube
     IMAGE=$BASE:$VERSION
-    docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t "$IMAGE" -t $BASE:latest --push.
+    docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t "$IMAGE" -t $BASE:latest --push .
 fi


### PR DESCRIPTION
Fixes a lame typo.
`shellcheck` missed this.