### PR TITLE
chore: improve release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,9 +79,9 @@ jobs:
           echo "Creating release $version"
           # if version contains -rc, publish as a pre-release and don't set as latest
           if [[ $version == *-rc* ]]; then
-            gh release create $version -t $version --generate-notes --prerelease --latest=false --verify-tag  build/${version}.tgz#helm.tar.gz
+            gh release create $version -t $version --generate-notes --prerelease --latest=false --verify-tag build/${version}.tgz#helm.tar.gz
           else
-            gh release create $version -t $version --generate-notes --verify-tag  build/${version}.tgz#helm.tar.gz
+            gh release create $version -t $version --generate-notes --verify-tag build/${version}.tgz#helm.tar.gz
           fi
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,6 +73,7 @@ jobs:
         with:
           release_name: ${{ steps.version.outputs.version }}
           tag_name: ${{ github.ref }}
+          prerelease: ${{ contains(github.ref, 'rc') }} # Release candidates are marked as pre-releases
 
       - name: Upload Helm Release Asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,3 +71,4 @@ jobs:
           token: ${{ github.token }}
           files: build/${{ steps.version.outputs.version }}.tgz
           prerelease: ${{ contains(github.ref, 'rc') }}
+          generate_release_notes: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,6 +69,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ github.token }}
+          tag_name: ${{ github.ref_name }}
           files: build/${{ steps.version.outputs.version }}.tgz
           prerelease: ${{ contains(github.ref, 'rc') }}
           generate_release_notes: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,22 +65,9 @@ jobs:
           gsutil -h "Cache-Control:no-cache,max-age=0" cp build/helm/${version}.tgz gs://helm.coder.com/logstream-kube
           gsutil -h "Cache-Control:no-cache,max-age=0" cp build/helm/index.yaml gs://helm.coder.com/logstream-kube
 
-      - name: Create Release
-        uses: actions/create-release@v1
-        id: create_release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - name: Create and upload release
+        uses: softprops/action-gh-release@v2
         with:
-          release_name: ${{ steps.version.outputs.version }}
-          tag_name: ${{ github.ref }}
-          prerelease: ${{ contains(github.ref, 'rc') }} # Release candidates are marked as pre-releases
-
-      - name: Upload Helm Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build/${{ steps.version.outputs.version }}.tgz
-          asset_name: helm.tar.gz
-          asset_content_type: application/gzip
+          token: ${{ github.token }}
+          files: build/${{ steps.version.outputs.version }}.tgz
+          prerelease: ${{ contains(github.ref, 'rc') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,9 +77,9 @@ jobs:
             echo "Creating release $version"
             # if version contains -rc, publish as a pre-release and not latest
             if [[ $version == *-rc* ]]; then
-              gh release create $version -t $version --generate-notes --prerelease --latest=false --verify-tag  build/${version}.tgz
+              gh release create $version -t $version --generate-notes --prerelease --latest=false --verify-tag  build/${version}.tgz#helm.tar.gz
             else
-              gh release create $version -t $version --generate-notes --verify-tag  build/${version}.tgz
+              gh release create $version -t $version --generate-notes --verify-tag  build/${version}.tgz#helm.tar.gz
             fi
           fi
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,10 +66,21 @@ jobs:
           gsutil -h "Cache-Control:no-cache,max-age=0" cp build/helm/index.yaml gs://helm.coder.com/logstream-kube
 
       - name: Create and upload release
-        uses: softprops/action-gh-release@v2
-        with:
-          token: ${{ github.token }}
-          tag_name: ${{ github.ref_name }}
-          files: build/${{ steps.version.outputs.version }}.tgz
-          prerelease: ${{ contains(github.ref, 'rc') }}
-          generate_release_notes: true
+        run: |
+          set -euo pipefail
+          version=${{ steps.version.outputs.version }}
+
+          if gh release view $version; then
+            echo "Release $version already exists"
+            exit 0
+          else
+            echo "Creating release $version"
+            # if version contains -rc, publish as a pre-release and not latest
+            if [[ $version == *-rc* ]]; then
+              gh release create $version -t $version --generate-notes --prerelease --latest=false --verify-tag  build/${version}.tgz
+            else
+              gh release create $version -t $version --generate-notes --verify-tag  build/${version}.tgz
+            fi
+          fi
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,17 +70,18 @@ jobs:
           set -euo pipefail
           version=${{ steps.version.outputs.version }}
 
-          if gh release view $version; then
+          # check if release already exists and match the version
+          if [[ $(gh release view $version --json name -q '.name' | cat) == $version ]]; then
             echo "Release $version already exists"
             exit 0
+          fi
+
+          echo "Creating release $version"
+          # if version contains -rc, publish as a pre-release and don't set as latest
+          if [[ $version == *-rc* ]]; then
+            gh release create $version -t $version --generate-notes --prerelease --latest=false --verify-tag  build/${version}.tgz#helm.tar.gz
           else
-            echo "Creating release $version"
-            # if version contains -rc, publish as a pre-release and not latest
-            if [[ $version == *-rc* ]]; then
-              gh release create $version -t $version --generate-notes --prerelease --latest=false --verify-tag  build/${version}.tgz#helm.tar.gz
-            else
-              gh release create $version -t $version --generate-notes --verify-tag  build/${version}.tgz#helm.tar.gz
-            fi
+            gh release create $version -t $version --generate-notes --verify-tag  build/${version}.tgz#helm.tar.gz
           fi
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,7 +33,7 @@ fi
 # Ensure the builder is bootstrapped and ready to use
 docker buildx inspect --bootstrap &>/dev/null
 
-# Build
+# Build and push the image
 if [ "$CI" = "false" ]; then
     docker buildx build --platform linux/"$current" -t coder-logstream-kube --load .
 else

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,5 +40,10 @@ else
     VERSION=$(../scripts/version.sh)
     BASE=ghcr.io/coder/coder-logstream-kube
     IMAGE=$BASE:$VERSION
-    docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t "$IMAGE" -t $BASE:latest --push .
+    # if version contains "rc" skip pushing to latest
+    if [[ $VERSION == *"rc"* ]]; then
+        docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t "$IMAGE" --push .
+    else
+        docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t "$IMAGE" -t $BASE:latest --push .
+    fi
 fi


### PR DESCRIPTION
This PR fixes a few things.

1. Fixes an issue where `rc` tags are marked as latest. I saw this with [`v0.0.11-rc.1`](https://github.com/coder/coder-logstream-kube/pkgs/container/coder-logstream-kube). 
2. Also, we are using deprecated actions; replace them `gh release create`.