### PR TITLE
feat: Add ability to define securityContext

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -85,6 +85,10 @@ spec:
             - name: SSL_CERT_DIR
               value: {{ .Values.image.sslCertDir }}
             {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.volumeMounts }}
           volumeMounts: {{- toYaml .Values.volumeMounts | nindent 12 }}
           {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -89,3 +89,15 @@ tolerations:
 # labels -- The pod labels for coder-logstream-kube. See:
 # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 labels: {}
+
+# securityContext -- Container-level security context
+# See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext: {}
+  # allowPrivilegeEscalation: false
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # seccompProfile:
+  #   type: RuntimeDefault


### PR DESCRIPTION
I'd like to define a securityContext to harden the deployment as much as possible.

_Setting the securityContext is already possible for the `coder` helm chart but sadly not for the logstream component_ :)