### PR TITLE
feat(helm): add support for disabling RBAC via rbac.enabled flag

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.rbac.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -29,6 +30,7 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount.name | quote }}
 ---
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,6 +5,11 @@ url: ""
 # If unspecified, this defaults to the Helm namespace.
 namespace: ""
 
+# rbac -- Specifies whether the RBAC components are installed.
+# If enabled is set to false, the RBAC components must be installed outside of the Helm Chart
+rbac:
+  enabled: true
+
 # volumes -- A list of extra volumes to add to the coder-logstream pod.
 volumes:
   #   emptyDir: {}


### PR DESCRIPTION
Adds support for disabling RBAC components in the template which is especially important for enterprises where users are not allowed to create rbac related resources.