### PR TITLE
run image as non-root user & add securitycontext values

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -98,6 +98,10 @@ spec:
       nodeSelector:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      podSecurityContext:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: coder-logstream-kube
           image: "{{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -92,7 +92,14 @@ labels: {}
 
 # securityContext -- Container-level security context
 # See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-securityContext: {}
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  allowPrivilegeEscalation: false
+  # Optional; enable after validation if the app never writes to disk:
+  # readOnlyRootFilesystem: true
+  #
   # allowPrivilegeEscalation: false
   # capabilities:
   #   drop:
@@ -101,3 +108,8 @@ securityContext: {}
   # runAsNonRoot: true
   # seccompProfile:
   #   type: RuntimeDefault
+
+podSecurityContext: {}
+# Optional, only if your cluster requires group ownership for mounted volumes:
+# podSecurityContext:
+#   fsGroup: 65532

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -97,10 +97,6 @@ securityContext:
   runAsUser: 65532
   runAsGroup: 65532
   allowPrivilegeEscalation: false
-  # Optional; enable after validation if the app never writes to disk:
-  # readOnlyRootFilesystem: true
-  #
-  # allowPrivilegeEscalation: false
   # capabilities:
   #   drop:
   #   - ALL

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,5 @@
 FROM --platform=$BUILDPLATFORM scratch AS base
 ARG TARGETARCH
-COPY ./coder-logstream-kube-${TARGETARCH} /coder-logstream-kube
+COPY --chmod=0555 ./coder-logstream-kube-${TARGETARCH} /coder-logstream-kube
+USER 65532:65532
 ENTRYPOINT ["/coder-logstream-kube"]


### PR DESCRIPTION
prospective customer gave feedback that the `coder-logstream-kube` image runs as an undefined user, raising security flags.

this PR runs the image as a non-root user `65532` (compatible with `scratch` images, `/etc/passwd` not required), and adds support for `podSecurityContext` values.

closes #23