### PR TITLE
fix: use WaitForCacheSync instead of time.Sleep in flaky test

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -466,6 +466,9 @@ func Test_newPodEventLogger_multipleNamespaces(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Wait for informer caches to sync before creating pods
+	require.True(t, reporter.WaitForCacheSync(ctx), "informer caches failed to sync")
+
 	// Create a pod in the test-namespace1 namespace
 	pod1 := &corev1.Pod{
 		ObjectMeta: v1.ObjectMeta{


### PR DESCRIPTION
The `Test_newPodEventLogger_multipleNamespaces` test was flaky because informers might not have started watching before pods were created.

**Changes:**
- Add `hasSyncedFuncs` field to `podEventLogger` to track informer sync functions
- Add `WaitForCacheSync()` method using `cache.WaitForCacheSync`
- Replace `time.Sleep` with `WaitForCacheSync` in the test

This follows the proper Kubernetes pattern for waiting until informers are ready to receive events.