### PR TITLE
fix: change k8s event log level from Info to Debug

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -218,7 +218,7 @@ func (p *podEventLogger) initNamespace(namespace string) error {
 					p.sendLog(pod.Name, token, agentsdk.Log{
 						CreatedAt: time.Now(),
 						Output:    fmt.Sprintf("🐳 %s: %s", newColor(color.Bold).Sprint("Created pod"), pod.Name),
-						Level:     codersdk.LogLevelInfo,
+						Level:     codersdk.LogLevelDebug,
 					})
 				}
 			}
@@ -287,7 +287,7 @@ func (p *podEventLogger) initNamespace(namespace string) error {
 					p.sendLog(replicaSet.Name, token, agentsdk.Log{
 						CreatedAt: time.Now(),
 						Output:    fmt.Sprintf("🐳 %s: %s", newColor(color.Bold).Sprint("Queued pod from ReplicaSet"), replicaSet.Name),
-						Level:     codersdk.LogLevelInfo,
+						Level:     codersdk.LogLevelDebug,
 					})
 				}
 			}
@@ -351,7 +351,7 @@ func (p *podEventLogger) initNamespace(namespace string) error {
 				p.sendLog(event.InvolvedObject.Name, token, agentsdk.Log{
 					CreatedAt: time.Now(),
 					Output:    newColor(color.FgWhite).Sprint(event.Message),
-					Level:     codersdk.LogLevelInfo,
+					Level:     codersdk.LogLevelDebug,
 				})
 				p.logger.Info(p.ctx, "sending log", slog.F("pod", event.InvolvedObject.Name), slog.F("message", event.Message))
 			}

--- a/logger_test.go
+++ b/logger_test.go
@@ -684,7 +684,7 @@ func Test_logQueuer(t *testing.T) {
 			log: agentsdk.Log{
 				CreatedAt: time.Now(),
 				Output:    "This is a log.",
-				Level:     codersdk.LogLevelInfo,
+				Level:     codersdk.LogLevelDebug,
 			},
 		}
 
@@ -700,7 +700,7 @@ func Test_logQueuer(t *testing.T) {
 			log: agentsdk.Log{
 				CreatedAt: time.Now(),
 				Output:    "This is a log too.",
-				Level:     codersdk.LogLevelInfo,
+				Level:     codersdk.LogLevelDebug,
 			},
 		}
 
@@ -752,7 +752,7 @@ func Test_logQueuer(t *testing.T) {
 			log: agentsdk.Log{
 				CreatedAt: time.Now(),
 				Output:    "This is a log.",
-				Level:     codersdk.LogLevelInfo,
+				Level:     codersdk.LogLevelDebug,
 			},
 		}
 
@@ -915,7 +915,7 @@ func Test_logQueuer(t *testing.T) {
 			log: agentsdk.Log{
 				CreatedAt: time.Now(),
 				Output:    "This is a log.",
-				Level:     codersdk.LogLevelInfo,
+				Level:     codersdk.LogLevelDebug,
 			},
 		}
 
@@ -973,7 +973,7 @@ func Test_logCache(t *testing.T) {
 			log: agentsdk.Log{
 				CreatedAt: time.Now(),
 				Output:    "First log",
-				Level:     codersdk.LogLevelInfo,
+				Level:     codersdk.LogLevelDebug,
 			},
 		}
 		returnedLogs := lc.push(log1)
@@ -1021,7 +1021,7 @@ func Test_logCache(t *testing.T) {
 			log: agentsdk.Log{
 				CreatedAt: time.Now(),
 				Output:    "Test log",
-				Level:     codersdk.LogLevelInfo,
+				Level:     codersdk.LogLevelDebug,
 			},
 		}
 		lc.push(log)
@@ -1054,7 +1054,7 @@ func Test_logCache(t *testing.T) {
 			log: agentsdk.Log{
 				CreatedAt: time.Now(),
 				Output:    "Log for token1",
-				Level:     codersdk.LogLevelInfo,
+				Level:     codersdk.LogLevelDebug,
 			},
 		}
 		log2 := agentLog{
@@ -1149,7 +1149,7 @@ func Test_logCache(t *testing.T) {
 			log: agentsdk.Log{
 				CreatedAt: time.Now(),
 				Output:    "Real log",
-				Level:     codersdk.LogLevelInfo,
+				Level:     codersdk.LogLevelDebug,
 			},
 		}
 		ch <- realLog


### PR DESCRIPTION
Fixes #145

## Summary
Kubernetes events sent from coder-logstream-kube to Coder were displayed with a green border because they used `LogLevelInfo`. This confused users who associate green with "workspace ready".

## Changes
Changed `codersdk.LogLevelInfo` to `codersdk.LogLevelDebug` in 3 places in `logger.go`:
- "Created pod" log
- "Queued pod from ReplicaSet" log
- Event message log

This prevents the interim events (PVC/PV attach, image pull, etc.) from appearing with the same visual indicator as the final ready state.

## Testing
- All existing tests updated and passing