### PR TITLE
feat: Add option to assign field-selector and label-selector

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -138,6 +138,14 @@ spec:
             - name: CODER_NAMESPACES
               value: {{ join "," .Values.namespaces }}
             {{- end }}
+            {{- if .Values.fieldSelector }}
+            - name: CODER_FIELD_SELECTOR
+              value: {{ .Values.fieldSelector | quote }}
+            {{- end }}
+            {{- if .Values.labelSelector }}
+            - name: CODER_LABEL_SELECTOR
+              value: {{ .Values.labelSelector | quote }}
+            {{- end }}
             {{- if .Values.image.sslCertFile }}
             - name: SSL_CERT_FILE
               value: {{ .Values.image.sslCertFile }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,6 +5,14 @@ url: ""
 # If unspecified or empty it will watch all namespaces.
 namespaces: []
 
+# fieldSelector -- Kubernetes field selector for filtering pods.
+# Use this filter instead of .values.namespaces
+fieldSelector: ""
+
+# labelSelector -- Kubernetes label selector for filtering pods
+# Use this filter instead of .values.namespaces
+labelSelector: ""
+
 # volumes -- A list of extra volumes to add to the coder-logstream pod.
 volumes:
   #   emptyDir: {}


### PR DESCRIPTION
Add option to assign field-selector and label-selector for filtering pods to listen events from, instead of adding coder namespaces in the `.values.namespaces: []` list

- Setting `fieldSelector: "some-label"` will assign this label to environment variables: `CODER_FIELD_SELECTOR` for the deployment
- Setting `labelSelector: "some-label"` will assign this label to environment variables: `CODER_LABEL_SELECTOR` for the deployment


Relates to: https://github.com/coder/coder-logstream-kube/issues/192