### PR TITLE
feat: add args support to helm chart

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -117,6 +117,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /coder-logstream-kube
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.metrics.enabled }}
           ports:
             - name: metrics

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -15,6 +15,9 @@ volumeMounts:
   # - name: "my-volume"
   #   mountPath: "/mnt/my-volume"
 
+# args -- A list of arguments to supply at runtime
+args: []
+
 # image -- The image to use.
 image:
   # image.repo -- The repository of the image.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -15,7 +15,7 @@ volumeMounts:
   # - name: "my-volume"
   #   mountPath: "/mnt/my-volume"
 
-# args -- A list of arguments to supply at runtime
+# args -- A list of optional arguments to supply at runtime.
 args: []
 
 # image -- The image to use.


### PR DESCRIPTION
adds support for specifying runtime arguments via the helm chart in case they are not exposed as env vars natively in the chart.

Current state:
```
coder@white-meadowlark-38:~/coder-logstream-kube$ helm template coder-logstream-kube helm | grep -A10 'containers:'
      containers:
        - name: coder-logstream-kube
          image: "ghcr.io/coder/coder-logstream-kube:0.1.0"
          imagePullPolicy: IfNotPresent
          command:
            - /coder-logstream-kube
          resources: 
            {}
          env:
            - name: CODER_URL
              value: 
```

And with this added:
```
coder@white-meadowlark-38:~/coder-logstream-kube$ helm template coder-logstream-kube helm/ --set 'args[0]=-l' --set 'args[1]=com.coder.deployment=dev-coder.mcrn.cc' | grep -A10 'containers:'
      containers:
        - name: coder-logstream-kube
          image: "ghcr.io/coder/coder-logstream-kube:0.1.0"
          imagePullPolicy: IfNotPresent
          command:
            - /coder-logstream-kube
          args:
            - -l
            - com.coder.deployment=dev-coder.mcrn.cc
          resources: 
            {}
```

