### PR TITLE
fix: update log level to debug for in progress events sent to Kubernetes/Coder

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -237,7 +237,7 @@ func (p *podEventLogger) initNamespace(namespace string) error {
 					p.sendLog(pod.Name, token, agentsdk.Log{
 						CreatedAt: time.Now(),
 						Output:    fmt.Sprintf("🐳 %s: %s", newColor(color.Bold).Sprint("Created pod"), pod.Name),
-						Level:     codersdk.LogLevelInfo,
+						Level:     codersdk.LogLevelDebug,
 					})
 				}
 			}
@@ -306,7 +306,7 @@ func (p *podEventLogger) initNamespace(namespace string) error {
 					p.sendLog(replicaSet.Name, token, agentsdk.Log{
 						CreatedAt: time.Now(),
 						Output:    fmt.Sprintf("🐳 %s: %s", newColor(color.Bold).Sprint("Queued pod from ReplicaSet"), replicaSet.Name),
-						Level:     codersdk.LogLevelInfo,
+						Level:     codersdk.LogLevelDebug,
 					})
 				}
 			}
@@ -370,7 +370,7 @@ func (p *podEventLogger) initNamespace(namespace string) error {
 				p.sendLog(event.InvolvedObject.Name, token, agentsdk.Log{
 					CreatedAt: time.Now(),
 					Output:    newColor(color.FgWhite).Sprint(event.Message),
-					Level:     codersdk.LogLevelInfo,
+					Level:     codersdk.LogLevelDebug,
 				})
 				p.logger.Info(p.ctx, "sending log", slog.F("pod", event.InvolvedObject.Name), slog.F("message", event.Message))
 			}


### PR DESCRIPTION
closes #145 

This corrects the behaviour of events sent to Kubernetes to ensure Coder shows them with a blue border instead of a green, thus not implying the workspace is ready.

builds on the changes implemented in #168

With a test build, an example of image pull failure staying blue:

https://github.com/user-attachments/assets/ba05d3e6-a97b-49a9-8afb-a8dfc2fb8925

With a test build, an example of image pull staying blue (image has to be pulled, does not exist locally):

https://github.com/user-attachments/assets/f027e330-81f5-4b07-8848-3d1dd58c1ced

