### PR TITLE
chore: update from Go 1.25.7 to Go 1.26.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: "~1.25"
+          go-version: "~1.26"
 
       - name: Test
         run: go test ./... -race
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: "~1.25"
+          go-version: "~1.26"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: "~1.25"
+          go-version: "~1.26"
 
       - name: Create KinD cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: "~1.24"
+          go-version: "~1.26"
 
       - name: Get Version
         run: echo "version=$(./scripts/version.sh)" >> $GITHUB_OUTPUT

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coder/coder-logstream-kube
 
-go 1.25.7
+go 1.26.4
 
 // Required to import the agentsdk!
 replace tailscale.com => github.com/coder/tailscale v1.1.1-0.20250829055706-6eafe0f9199e


### PR DESCRIPTION
Updates go.mod to 1.26.4 and the CI runs to 1.26. Created a test build and validated it still functions as expected as part of the change.