### PR TITLE
feat: Add helm template support for rbac and deployment naming

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -16,7 +16,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: coder-logstream-kube-role
+  name: {{ $.Values.rbac.roleName }}
   namespace: {{ . }}
 rules:
 {{ include "coder-logstream-kube.rules" . | nindent 2 }}
@@ -24,12 +24,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: coder-logstream-kube-rolebinding
+  name: {{ $.Values.rbac.roleBindingName }}
   namespace: {{ . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: coder-logstream-kube-role
+  name: {{ $.Values.rbac.roleName }}
 subjects:
 - kind: ServiceAccount
   name: {{ $.Values.serviceAccount.name | quote }}
@@ -40,18 +40,18 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: coder-logstream-kube-role
+  name: {{ $.Values.rbac.roleName }}
 rules:
 {{ include "coder-logstream-kube.rules" . | nindent 2 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: coder-logstream-kube-rolebinding
+  name: {{ $.Values.rbac.roleBindingName }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: coder-logstream-kube-role
+  name: {{ $.Values.rbac.roleName }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount.name | quote }}
@@ -68,7 +68,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: coder-logstream-kube
+  name: {{ .Release.Name }}
 spec:
   # This must remain at 1 otherwise duplicate logs can occur!
   replicas: 1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -57,6 +57,12 @@ serviceAccount:
   # coder.serviceAccount.name -- The service account name
   name: coder-logstream-kube
 
+rbac:
+  # rbac.roleName -- The name of the role created in Kubernetes.
+  roleName: coder-logstream-kube
+  # rbac.roleBindingName -- The name of the role binding created in Kubernetes.
+  roleBindingName: coder-logstream-kube-rolebinding
+
 # resources -- The resources to request for the Deployment. These are optional
 # and are not set by default.
 resources:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -59,7 +59,7 @@ serviceAccount:
 
 rbac:
   # rbac.roleName -- The name of the role created in Kubernetes.
-  roleName: coder-logstream-kube
+  roleName: coder-logstream-kube-role
   # rbac.roleBindingName -- The name of the role binding created in Kubernetes.
   roleBindingName: coder-logstream-kube-rolebinding
 


### PR DESCRIPTION
adds support for custom naming of rbac name values, plus uses the helm release name for the deployment name.

this is primarily done in order to support multiple deployments of coder-logstream-kube in one kubernetes cluster, with each deployment specifying a distinct `url` value for distinct Coder deployments. In this setup both Coder deployments create Kubernetes based Coder workloads in the Kubernetes namespace.

Namespaced, with role + rolebinding:
```
coder@white-meadowlark-38:~/coder-logstream-kube$ helm template coder-logstream-kube-test \
helm -n clk --set namespaces[0]=coder-workloads \
--set rbac.roleName=dev-role \
--set rbac.roleBindingName=dev-role-binding \
| egrep -A2 'Deployment|kind: Role|kind: RoleBinding'
kind: Role
metadata:
  name: dev-role
--
kind: RoleBinding
metadata:
  name: dev-role-binding
--
  kind: Role
  name: dev-role
subjects:
--
kind: Deployment
metadata:
  name: coder-logstream-kube-test
```

Not namespaced, clusterrole + clusterrolebinding
```
coder@white-meadowlark-38:~/coder-logstream-kube$ helm template coder-logstream-kube-test \
helm -n clk \
--set rbac.roleName=dev-role \
--set rbac.roleBindingName=dev-role-binding \
| egrep -A2 'Deployment|kind: ClusterRole|kind: ClusterRoleBinding'
kind: ClusterRole
metadata:
  name: dev-role
--
kind: ClusterRoleBinding
metadata:
  name: dev-role-binding
--
  kind: ClusterRole
  name: dev-role
subjects:
--
kind: Deployment
metadata:
  name: coder-logstream-kube-test
```