### PR TITLE
fix: tests: buffer the logSource channel

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -1274,8 +1274,8 @@ func newFakeAgentAPI(t *testing.T) *fakeAgentAPI {
 	mux := drpcmux.New()
 	fakeAPI := &fakeAgentAPI{
 		disconnect: make(chan struct{}),
-		logs:       make(chan []*proto.Log),
-		logSource:  make(chan agentsdk.PostLogSourceRequest),
+		logs:       make(chan []*proto.Log, 32),
+		logSource:  make(chan agentsdk.PostLogSourceRequest, 32),
 	}
 	err := proto.DRPCRegisterAgent(mux, fakeAPI)
 	require.NoError(t, err)
@@ -1340,8 +1340,8 @@ func newFakeAgentAPI(t *testing.T) *fakeAgentAPI {
 func newFailingAgentAPI(t *testing.T) *fakeAgentAPI {
 	fakeAPI := &fakeAgentAPI{
 		disconnect: make(chan struct{}),
-		logs:       make(chan []*proto.Log),
-		logSource:  make(chan agentsdk.PostLogSourceRequest),
+		logs:       make(chan []*proto.Log, 32),
+		logSource:  make(chan agentsdk.PostLogSourceRequest, 32),
 	}
 
 	// Create a server that always returns 401 Unauthorized errors


### PR DESCRIPTION
Bug: fakeAgentAPI.PostLogSource sends on an unbuffered logSource channel, which blocks the HTTP handler goroutine if a second PostLogSource call arrives after the test has stopped reading (e.g. from a Kubernetes-spawned pod retrying after a context canceled), causing httptest.Server.Close() to deadlock waiting for the handler to finish.

Fix: Buffer the logSource and logs channels with a capacity of 32, allowing the fake server to absorb all incoming calls without blocking regardless of whether the test is actively reading.

example failure: https://github.com/coder/coder-logstream-kube/actions/runs/27814097460/job/82310947374?pr=201#step:5:472

prior to making changes when testing with:
```
pass=0; fail=0
for i in $(seq 1 100); do
  if GOTOOLCHAIN=auto go test -count=1 -v -tags=integration \
  -run 'TestIntegration_ReplicaSetEvents|Test_logQueuer/RetryMechanism' \
  -timeout 30s ./... > /tmp/run-$i.log 2>&1; then
    ((pass++)); rm /tmp/run-$i.log
  else
    ((fail++))
  fi
  printf "Run %3d/100 — pass: %d  fail: %d\n" $i $pass $fail
done
printf "\nFinal: %d passed, %d failed out of 100\n" $pass $fail
```

it would produce a failure rate of 4/100.

post change testing again resulted in 0 failures.

_created in Mux with the help of Claude_

